### PR TITLE
Remove unused ruby setup rules from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,22 +39,6 @@
         "eslint"
       ],
       "groupName": "ESLint updates"
-    },
-    {
-      "description": "Group ruby/setup-ruby action with ruby version updates",
-      "matchPackageNames": [
-        "ruby/setup-ruby",
-        "ruby"
-      ],
-      "groupName": "ruby setup",
-      "internalChecksFilter": "strict"
-    },
-    {
-      "description": "Let setup-ruby pass age gate before ruby so it is ready when the group PR is created",
-      "matchPackageNames": [
-        "ruby/setup-ruby"
-      ],
-      "minimumReleaseAge": "5 days"
     }
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
This project does not use Ruby. The ruby/setup-ruby grouping rules were added by mistake and serve no purpose here.