### PR TITLE
fix: support code fence examples nested in a longer fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # mkdocs-material-linter changelog
 
+## 1.5.4 (2026-08-09)
+
+- [Fix] `material-code-block-syntax` and `material-blank-lines-spacing` no longer flag code fence examples nested inside a longer fence (e.g. a ` ``` ` block shown inside a ` ```` ` block). A fence now only closes with at least as many backticks as the one that opened it, matching CommonMark behavior ([#24](https://github.com/mensfeld/mkdocs-material-linter/issues/24))
+- [Enhancement] Wired the previously orphaned `code-block-syntax` and `blank-lines-spacing` test suites into the test runner so their cases actually execute
+
 ## 1.5.3 (2025-09-01)
 
 - [Feature] `material-blank-lines-spacing` rule ensures blank lines before and after headers and after code blocks

--- a/lib/rules/blank-lines-spacing.js
+++ b/lib/rules/blank-lines-spacing.js
@@ -6,9 +6,12 @@ module.exports = {
   function: function rule(params, onError) {
     const lines = params.lines;
     const headerRegex = /^#{1,6}\s+/;
-    const codeBlockEndRegex = /^```/;
+    const codeFenceRegex = /^(`{3,})/;
 
-    let inCodeBlock = false;
+    // Length of the backtick run that opened the current fence (0 = not in a
+    // code block). A fence only closes with at least as many backticks, so a
+    // shorter fence inside a longer one is literal content, not a delimiter.
+    let codeFenceLength = 0;
     let inAdmonition = false;
     let admonitionIndent = 0;
 
@@ -38,13 +41,14 @@ module.exports = {
       }
 
       // Track code blocks
-      if (codeBlockEndRegex.test(trimmedLine)) {
-        if (!inCodeBlock) {
-          inCodeBlock = true;
+      const fenceMatch = trimmedLine.match(codeFenceRegex);
+      if (fenceMatch && (codeFenceLength === 0 || fenceMatch[1].length >= codeFenceLength)) {
+        if (codeFenceLength === 0) {
+          codeFenceLength = fenceMatch[1].length;
           continue;
         } else {
           // Code block is ending
-          inCodeBlock = false;
+          codeFenceLength = 0;
 
           // Check if there's a blank line after the code block
           // Skip if it's the last line or if we're inside an admonition
@@ -66,7 +70,7 @@ module.exports = {
       }
 
       // Skip checks inside code blocks
-      if (inCodeBlock) {
+      if (codeFenceLength > 0) {
         continue;
       }
 

--- a/lib/rules/code-block-syntax.js
+++ b/lib/rules/code-block-syntax.js
@@ -5,7 +5,7 @@ module.exports = {
   parser: 'markdownit',
   function: function rule(params, onError) {
     const lines = params.lines;
-    const codeBlockRegex = /^(\s*)```(.*)$/;
+    const codeBlockRegex = /^(\s*)(`{3,})(.*)$/;
     const admonitionRegex = /^(\?\?\?\+?\s+|!!!\s+)\S+/;
 
     // Stack to track open code blocks with their line numbers and indentation
@@ -40,7 +40,16 @@ module.exports = {
       const codeBlockMatch = line.match(codeBlockRegex);
       if (codeBlockMatch) {
         const indent = codeBlockMatch[1].length;
-        const afterTicks = codeBlockMatch[2];
+        const fenceLength = codeBlockMatch[2].length;
+        const afterTicks = codeBlockMatch[3];
+
+        // A fence can only be closed by one with at least as many backticks.
+        // So a shorter fence appearing inside a longer one is literal content,
+        // e.g. a ``` example nested inside a ```` markdown block. Skip it.
+        if (codeBlockStack.length > 0 &&
+            fenceLength < codeBlockStack[codeBlockStack.length - 1].fenceLength) {
+          continue;
+        }
 
         // Determine if this is opening or closing based on stack and indentation
         let isClosing = false;
@@ -91,6 +100,7 @@ module.exports = {
           codeBlockStack.push({
             lineNumber: lineNumber,
             indent: indent,
+            fenceLength: fenceLength,
             line: line.trim()
           });
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mkdocs-material-linter",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "markdownlint-cli2 custom rules for validating Material for MkDocs syntax including admonitions, content tabs, and code annotations",
   "main": "index.js",
   "scripts": {

--- a/test/rules/test-blank-lines-spacing.js
+++ b/test/rules/test-blank-lines-spacing.js
@@ -196,6 +196,21 @@ Content
           detail: 'Headers should be preceded by a blank line'
         }
       ]
+    },
+    {
+      name: 'Valid - code fence example inside a longer fence',
+      markdown: `
+\`\`\`\`markdown
+\`\`\`plantuml
+@startuml
+Alice -> Bob: hi
+@enduml
+\`\`\`
+\`\`\`\`
+
+Text after
+`,
+      errors: []
     }
   ]
 };

--- a/test/rules/test-code-block-syntax.js
+++ b/test/rules/test-code-block-syntax.js
@@ -237,6 +237,31 @@ Text
       ]
     },
     {
+      name: 'Valid - code fence example inside a longer fence',
+      markdown: `
+\`\`\`\`markdown
+\`\`\`plantuml
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml
+\`\`\`
+\`\`\`\`
+`,
+      errors: []
+    },
+    {
+      name: 'Valid - four-backtick fence wrapping a language-less block',
+      markdown: `
+\`\`\`\`
+\`\`\`
+some example
+\`\`\`
+\`\`\`\`
+`,
+      errors: []
+    },
+    {
       name: 'Invalid - truly nested unclosed blocks',
       markdown: `
 \`\`\`markdown

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -187,6 +187,58 @@ function runSpecificRuleTests() {
   }
 }
 
+/**
+ * Run data-style rule test suites that export { name, rule, tests: [...] }.
+ * Each test provides inline markdown and the exact errors it should produce.
+ * Returns the number of failing test cases.
+ */
+function runDataStyleRuleTests() {
+  console.log('🧪 Running data-style rule tests...\n');
+
+  const suites = [
+    require('./rules/test-code-block-syntax'),
+    require('./rules/test-blank-lines-spacing'),
+  ];
+
+  let failures = 0;
+
+  for (const suite of suites) {
+    console.log(`  📝 ${suite.name}`);
+    const names = Array.isArray(suite.rule.names) ? suite.rule.names : [suite.rule.names];
+
+    for (const test of suite.tests) {
+      const options = {
+        strings: { test: test.markdown },
+        customRules: [suite.rule],
+        config: { default: false, [names[0]]: true },
+        markdownItFactory: () => markdownIt()
+      };
+
+      const actual = (markdownlint(options).test) || [];
+      const expected = test.errors || [];
+
+      let passed = actual.length === expected.length;
+      if (passed) {
+        passed = expected.every(exp => actual.some(act =>
+          act.lineNumber === exp.lineNumber &&
+          (exp.detail === undefined || act.errorDetail === exp.detail)));
+      }
+
+      if (passed) {
+        console.log(`     ✅ ${test.name}`);
+      } else {
+        failures++;
+        console.log(`     ❌ ${test.name}`);
+        console.log(`        Expected ${expected.length} error(s): ${JSON.stringify(expected)}`);
+        console.log(`        Got ${actual.length}: ${JSON.stringify(actual.map(a => ({ lineNumber: a.lineNumber, detail: a.errorDetail })))}`);
+      }
+    }
+    console.log();
+  }
+
+  return failures;
+}
+
 // Run tests if this file is executed directly
 if (require.main === module) {
   console.log('mkdocs-material-linter Test Suite');
@@ -196,7 +248,8 @@ if (require.main === module) {
 
   try {
     runSpecificRuleTests();
-    const success = runTests();
+    const dataStyleFailures = runDataStyleRuleTests();
+    const success = runTests() && dataStyleFailures === 0;
     process.exit(success ? 0 : 1);
   } catch (error) {
     console.error('Test runner error:', error);


### PR DESCRIPTION
Closes #24

## Problem

Documenting Markdown means showing a fenced code block *inside* another fenced code block. The standard way is to wrap the inner ` ``` ` example in a longer ` ```` ` fence:

````markdown
```plantuml
@startuml
Alice -> Bob: Authentication Request
@enduml
```
````

The linter wrongly reported three errors on this valid input:

- `material-code-block-syntax` — "Code block closing tags must not have a language type" (×2)
- `material-blank-lines-spacing` — "Code blocks should be followed by a blank line"

## Cause

Both rules matched every ` ``` ` line as a fence delimiter regardless of its backtick count. So the inner ` ```plantuml ` was misread as *closing* the outer ` ```` ` block, and everything downstream got mis-parsed.

## Fix

Per CommonMark, a fence only closes with a fence of **at least as many backticks** as the one that opened it. Both rules now track the opening fence's backtick length and treat any shorter fence as literal content:

- `code-block-syntax.js` — capture the backtick run length; skip a fence shorter than the currently open one.
- `blank-lines-spacing.js` — track `codeFenceLength` instead of a boolean `inCodeBlock`.

Verified against the exact repro from the issue: the three errors are gone.

## Tests

The `test-code-block-syntax.js` and `test-blank-lines-spacing.js` suites (data-style `{ name, rule, tests }` files) were **never executed** by the runner — only 4 function-style suites and the fixtures ran. I wired them into `run-tests.js` (32 cases now run and gate the exit code) and added coverage for the nested-fence case. All existing cases still pass.

Note: bumped version to `1.5.4` and added a CHANGELOG entry — adjust if you'd rather version at release time.