### PR TITLE
fix: repair meta-tags/mermaid/footnotes rules and gate test exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # mkdocs-material-linter changelog
 
-## 1.5.4 (2026-08-09)
+## 1.5.4 (Unreleased)
 
 - [Fix] `material-code-block-syntax` and `material-blank-lines-spacing` no longer flag code fence examples nested inside a longer fence (e.g. a ` ``` ` block shown inside a ` ```` ` block). A fence now only closes with at least as many backticks as the one that opened it, matching CommonMark behavior ([#24](https://github.com/mensfeld/mkdocs-material-linter/issues/24))
+- [Fix] `material-meta-tags` now reads YAML front matter from `params.frontMatterLines` (markdownlint strips it out of `params.lines`), so pages that do have front matter are no longer always reported as missing it ([#80](https://github.com/mensfeld/mkdocs-material-linter/issues/80))
+- [Fix] `material-mermaid-syntax` checks bracket/brace balance across the whole block instead of per line, so multi-line `classDiagram`/`stateDiagram` bodies no longer produce false "unmatched braces" errors; edges like `A --> B` now count as node definitions ([#80](https://github.com/mensfeld/mkdocs-material-linter/issues/80))
+- [Fix] `material-footnotes-syntax` no longer counts a definition's own label as a reference to itself, fixing missed "definition never referenced" reports and spurious "reference has no definition" errors ([#80](https://github.com/mensfeld/mkdocs-material-linter/issues/80))
 - [Enhancement] Wired the previously orphaned `code-block-syntax` and `blank-lines-spacing` test suites into the test runner so their cases actually execute
+- [Enhancement] Failures in the `icons`, `meta-tags`, `mermaid`, and `footnotes` rule test suites now fail the `npm test` exit code instead of only printing to the console ([#80](https://github.com/mensfeld/mkdocs-material-linter/issues/80))
 
 ## 1.5.3 (2025-09-01)
 

--- a/lib/rules/material-footnotes-syntax.js
+++ b/lib/rules/material-footnotes-syntax.js
@@ -31,11 +31,22 @@ module.exports = {
         continue;
       }
 
-      // Find footnote references: [^1], [^note], [^my-note]
+      // A footnote definition starts a line with [^id]. A well-formed one has a
+      // colon ([^id]: content); a colon-less one ([^id] content) is malformed
+      // but still intended as a definition (flagged in the third pass), so we
+      // treat it as a definition here too.
+      const defStartMatch = line.match(/^\[\^([a-zA-Z0-9\-_]+)\]/);
+      const isDefinition = defStartMatch !== null;
+
+      // Find footnote references: [^1], [^note], [^my-note]. On a definition
+      // line, skip its own leading label so it isn't counted as a reference to
+      // itself (which would hide "definition never referenced" and inflate
+      // "reference has no definition" errors).
+      const referenceScan = isDefinition ? line.slice(defStartMatch[0].length) : line;
       const referenceRegex = /\[\^([a-zA-Z0-9\-_]+)\]/g;
       let match;
 
-      while ((match = referenceRegex.exec(line)) !== null) {
+      while ((match = referenceRegex.exec(referenceScan)) !== null) {
         const footnoteId = match[1];
 
         if (!footnoteReferences.has(footnoteId)) {
@@ -44,11 +55,9 @@ module.exports = {
         footnoteReferences.get(footnoteId).push(lineNumber);
       }
 
-      // Find footnote definitions: [^1]: Content
-      const definitionMatch = line.match(/^\[\^([a-zA-Z0-9\-_]+)\]:\s*(.*)$/);
-      if (definitionMatch) {
-        const footnoteId = definitionMatch[1];
-        const content = definitionMatch[2].trim();
+      // Register footnote definitions (well-formed and malformed alike).
+      if (isDefinition) {
+        const footnoteId = defStartMatch[1];
 
         if (footnoteDefinitions.has(footnoteId)) {
           // Duplicate definition
@@ -60,8 +69,9 @@ module.exports = {
         } else {
           footnoteDefinitions.set(footnoteId, lineNumber);
 
-          // Check if definition has content
-          if (!content) {
+          // Check if a well-formed "[^id]:" definition has content.
+          const wellFormedMatch = line.match(/^\[\^[a-zA-Z0-9\-_]+\]:\s*(.*)$/);
+          if (wellFormedMatch && !wellFormedMatch[1].trim()) {
             onError({
               lineNumber: lineNumber,
               detail: `Footnote definition "[^${footnoteId}]" is empty. Add content after the colon.`,

--- a/lib/rules/material-mermaid-syntax.js
+++ b/lib/rules/material-mermaid-syntax.js
@@ -104,10 +104,13 @@ function validateMermaidSyntax(mermaidLines, startLine, onError) {
       });
     }
 
-    // Check for basic node definitions
+    // Check for basic node definitions. Nodes can be declared with a shape
+    // ([], (), {}) or simply connected by an edge (A --> B), so an edge counts
+    // as defining nodes too.
     const hasNodes = /[A-Za-z0-9]+\[.*\]/.test(contentText) ||
                     /[A-Za-z0-9]+\(.*\)/.test(contentText) ||
-                    /[A-Za-z0-9]+\{.*\}/.test(contentText);
+                    /[A-Za-z0-9]+\{.*\}/.test(contentText) ||
+                    /-->|---|-\.->|==>|===|~~~|--[ox]|[ox]--/.test(contentText);
 
     if (!hasNodes) {
       onError({
@@ -168,40 +171,24 @@ function validateMermaidSyntax(mermaidLines, startLine, onError) {
     }
   }
 
-  // Check for common syntax errors
-  for (let i = 0; i < mermaidLines.length; i++) {
-    const line = mermaidLines[i];
-    const content = line.content.trim();
+  // Check for unmatched brackets across the whole block. Labels and class/state
+  // bodies legitimately span multiple lines (e.g. "class Animal {" ... "}"), so
+  // counting per line produces false positives; balance is a block-level check.
+  const bracketPairs = [
+    { open: /\[/g, close: /\]/g, detail: 'Unmatched square brackets in Mermaid diagram.' },
+    { open: /\(/g, close: /\)/g, detail: 'Unmatched parentheses in Mermaid diagram.' },
+    { open: /\{/g, close: /\}/g, detail: 'Unmatched curly braces in Mermaid diagram.' }
+  ];
 
-    // Check for unmatched brackets
-    const openBrackets = (content.match(/\[/g) || []).length;
-    const closeBrackets = (content.match(/\]/g) || []).length;
-    const openParens = (content.match(/\(/g) || []).length;
-    const closeParens = (content.match(/\)/g) || []).length;
-    const openBraces = (content.match(/\{/g) || []).length;
-    const closeBraces = (content.match(/\}/g) || []).length;
+  for (const pair of bracketPairs) {
+    const opens = (contentText.match(pair.open) || []).length;
+    const closes = (contentText.match(pair.close) || []).length;
 
-    if (openBrackets !== closeBrackets) {
+    if (opens !== closes) {
       onError({
-        lineNumber: line.lineNumber,
-        detail: 'Unmatched square brackets in Mermaid diagram.',
-        context: content
-      });
-    }
-
-    if (openParens !== closeParens) {
-      onError({
-        lineNumber: line.lineNumber,
-        detail: 'Unmatched parentheses in Mermaid diagram.',
-        context: content
-      });
-    }
-
-    if (openBraces !== closeBraces) {
-      onError({
-        lineNumber: line.lineNumber,
-        detail: 'Unmatched curly braces in Mermaid diagram.',
-        context: content
+        lineNumber: firstLine.lineNumber,
+        detail: pair.detail,
+        context: firstLine.content
       });
     }
   }

--- a/lib/rules/material-meta-tags.js
+++ b/lib/rules/material-meta-tags.js
@@ -8,36 +8,40 @@ module.exports = {
   function: function rule(params, onError) {
     const lines = params.lines;
 
-    // Check if file starts with YAML front matter
-    if (lines.length === 0 || lines[0].trim() !== '---') {
-      onError({
-        lineNumber: 1,
-        detail: 'Missing YAML front matter. Add metadata like description, tags, and template for better Material for MkDocs integration.',
-        context: lines[0] || ''
-      });
+    // markdownlint extracts YAML front matter into params.frontMatterLines and
+    // removes it from params.lines, so we must inspect frontMatterLines here.
+    // It contains the leading/trailing "---" delimiters (and a trailing blank).
+    const rawFrontMatter = params.frontMatterLines || [];
+
+    if (rawFrontMatter.length === 0) {
+      // No front matter was extracted. If the document still opens with "---",
+      // it's an unclosed block; otherwise there's no front matter at all.
+      if ((lines[0] || '').trim() === '---') {
+        onError({
+          lineNumber: 1,
+          detail: 'YAML front matter is not properly closed with "---".',
+          context: '---'
+        });
+      } else {
+        onError({
+          lineNumber: 1,
+          detail: 'Missing YAML front matter. Add metadata like description, tags, and template for better Material for MkDocs integration.',
+          context: lines[0] || ''
+        });
+      }
       return;
     }
 
-    // Find the end of front matter
-    let frontMatterEnd = -1;
-    for (let i = 1; i < lines.length; i++) {
-      if (lines[i].trim() === '---') {
-        frontMatterEnd = i;
+    // Collect the content lines between the opening and closing "---" delimiters.
+    const frontMatterLines = [];
+    for (let i = 1; i < rawFrontMatter.length; i++) {
+      if (rawFrontMatter[i].trim() === '---') {
         break;
       }
-    }
-
-    if (frontMatterEnd === -1) {
-      onError({
-        lineNumber: 1,
-        detail: 'YAML front matter is not properly closed with "---".',
-        context: '---'
-      });
-      return;
+      frontMatterLines.push(rawFrontMatter[i]);
     }
 
     // Parse front matter content
-    const frontMatterLines = lines.slice(1, frontMatterEnd);
     const metadata = {};
 
     for (let i = 0; i < frontMatterLines.length; i++) {
@@ -65,11 +69,16 @@ module.exports = {
       }
     ];
 
+    // Front matter is stripped from params.lines by markdownlint, so its lines
+    // are not addressable by onError (only body line numbers are valid). Report
+    // all metadata findings at line 1, the closest we can point to the top.
+    const frontMatterLine = 1;
+
     // Check for missing recommended fields
     for (const rec of recommendations) {
       if (!metadata[rec.key] || metadata[rec.key] === '') {
         onError({
-          lineNumber: 2,
+          lineNumber: frontMatterLine,
           detail: rec.message,
           context: '---'
         });
@@ -79,7 +88,7 @@ module.exports = {
     // Validate description length
     if (metadata.description && metadata.description.length > 160) {
       onError({
-        lineNumber: 2,
+        lineNumber: frontMatterLine,
         detail: 'Description should be under 160 characters for optimal SEO.',
         context: `description: ${metadata.description}`
       });
@@ -90,7 +99,7 @@ module.exports = {
       const validTemplates = ['main.html', 'blog.html', 'landing.html'];
       if (!validTemplates.includes(metadata.template) && !metadata.template.endsWith('.html')) {
         onError({
-          lineNumber: 2,
+          lineNumber: frontMatterLine,
           detail: 'Template should be a valid HTML template file (e.g., main.html).',
           context: `template: ${metadata.template}`
         });
@@ -103,7 +112,7 @@ module.exports = {
       const tagLine = frontMatterLines.find(line => line.toLowerCase().includes('tags:'));
       if (tagLine && !tagLine.includes('[') && !tagLine.includes('-')) {
         onError({
-          lineNumber: frontMatterLines.indexOf(tagLine) + 2,
+          lineNumber: frontMatterLine,
           detail: 'Tags should be formatted as a YAML list (e.g., tags: [tag1, tag2] or use bullet points).',
           context: tagLine
         });
@@ -118,7 +127,7 @@ module.exports = {
       for (const value of hideValues) {
         if (!hideOptions.includes(value)) {
           onError({
-            lineNumber: 2,
+            lineNumber: frontMatterLine,
             detail: `Invalid hide option "${value}". Valid options are: navigation, toc.`,
             context: `hide: ${metadata.hide}`
           });

--- a/test/rules/test-material-footnotes-syntax.js
+++ b/test/rules/test-material-footnotes-syntax.js
@@ -134,6 +134,17 @@ First[^1] and third[^3] footnotes, skipping second.
     },
 
     {
+      name: 'Orphan definition among valid ones',
+      content: `# Mixed References
+
+Referenced[^used] footnote here.
+
+[^used]: This one is referenced.
+[^orphan]: This one is not referenced.`,
+      expectedErrors: 1
+    },
+
+    {
       name: 'Multiple errors',
       content: `# Multiple Issues
 
@@ -182,9 +193,8 @@ Reference[^1] and missing[^missing] and duplicate[^dup].
     }
   });
 
-  setTimeout(() => {
-    console.log(`Material Footnotes Syntax Tests: ${passed}/${total} passed\n`);
-  }, 100);
+  console.log(`Material Footnotes Syntax Tests: ${passed}/${total} passed\n`);
+  return total - passed;
 }
 
 module.exports = { runMaterialFootnotesSyntaxTests };

--- a/test/rules/test-material-icons-valid.js
+++ b/test/rules/test-material-icons-valid.js
@@ -107,9 +107,8 @@ Simple icons are not validated: :simple-python: :simple-javascript: :simple-none
     }
   });
 
-  setTimeout(() => {
-    console.log(`Material Icons Valid Tests: ${passed}/${total} passed\n`);
-  }, 100);
+  console.log(`Material Icons Valid Tests: ${passed}/${total} passed\n`);
+  return total - passed;
 }
 
 module.exports = { runMaterialIconsValidTests };

--- a/test/rules/test-material-mermaid-syntax.js
+++ b/test/rules/test-material-mermaid-syntax.js
@@ -58,6 +58,20 @@ classDiagram
       expectedErrors: 0
     },
 
+    {
+      name: 'Valid state diagram with multi-line braces',
+      content: `# State Diagram
+
+\`\`\`mermaid
+stateDiagram-v2
+    state Fork {
+        [*] --> Active
+        Active --> [*]
+    }
+\`\`\``,
+      expectedErrors: 0
+    },
+
     // Invalid cases
     {
       name: 'Empty mermaid block',
@@ -219,9 +233,8 @@ invalidDiagram
     }
   });
 
-  setTimeout(() => {
-    console.log(`Material Mermaid Syntax Tests: ${passed}/${total} passed\n`);
-  }, 100);
+  console.log(`Material Mermaid Syntax Tests: ${passed}/${total} passed\n`);
+  return total - passed;
 }
 
 module.exports = { runMaterialMermaidSyntaxTests };

--- a/test/rules/test-material-meta-tags.js
+++ b/test/rules/test-material-meta-tags.js
@@ -36,6 +36,21 @@ Minimal but valid.`,
       expectedErrors: 0
     },
 
+    {
+      name: 'Front matter with list-style tags',
+      content: `---
+title: Page Title
+description: A valid description.
+tags:
+  - seo
+  - metadata
+---
+
+# Content
+Tags as a YAML block list.`,
+      expectedErrors: 0
+    },
+
     // Cases with warnings/errors
     {
       name: 'Missing front matter',
@@ -68,7 +83,7 @@ No description provided.`,
       name: 'Long description',
       content: `---
 title: Page Title
-description: This is a very long description that exceeds the recommended 160 character limit for SEO purposes and should trigger a warning about the length.
+description: This is a very long description that clearly exceeds the recommended 160 character limit for SEO purposes and should reliably trigger a warning about the excessive length of this text.
 ---
 
 # Content
@@ -164,9 +179,8 @@ Valid hide options.`,
     }
   });
 
-  setTimeout(() => {
-    console.log(`Material Meta Tags Tests: ${passed}/${total} passed\n`);
-  }, 100);
+  console.log(`Material Meta Tags Tests: ${passed}/${total} passed\n`);
+  return total - passed;
 }
 
 module.exports = { runMaterialMetaTagsTests };

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -176,15 +176,17 @@ function runSpecificRuleTests() {
     require('./rules/test-material-footnotes-syntax'),
   ];
 
-  // Run each test suite
+  // Run each test suite, summing the number of failing cases so callers can
+  // gate the process exit code on them.
+  let failures = 0;
   for (const testModule of tests) {
     const testFunction = Object.values(testModule)[0];
     if (typeof testFunction === 'function') {
-      testFunction();
-      // Add a small delay to ensure proper output ordering
-      // Removed async delay
+      failures += testFunction() || 0;
     }
   }
+
+  return failures;
 }
 
 /**
@@ -247,9 +249,9 @@ if (require.main === module) {
   testIndividualRules();
 
   try {
-    runSpecificRuleTests();
+    const specificFailures = runSpecificRuleTests();
     const dataStyleFailures = runDataStyleRuleTests();
-    const success = runTests() && dataStyleFailures === 0;
+    const success = runTests() && dataStyleFailures === 0 && specificFailures === 0;
     process.exit(success ? 0 : 1);
   } catch (error) {
     console.error('Test runner error:', error);


### PR DESCRIPTION
Closes #80

The test runner ran the `icons`, `meta-tags`, `mermaid`, and `footnotes` suites but only **logged** their results — failures never reached `process.exit`, so `npm test` printed `❌` lines yet still exited `0`. That hid 8 failing cases, each of which turned out to be a genuine rule bug (or, in one case, a stale expectation).

## Part 1 — make failures fail the build

Each function-style suite now returns its failure count, and `run-tests.js` factors those into the exit code (alongside the fixture and data-style suites). Verified: injecting a bad expectation now yields exit `1`; reverting returns to `0`.

## Part 2 — fix the bugs the gate exposed

### `material-meta-tags` (3 cases)
markdownlint strips YAML front matter into `params.frontMatterLines` and removes it from `params.lines`. The rule read `params.lines`, so **every page with front matter was reported as missing it**. Now it reads `frontMatterLines`. Front-matter lines aren't addressable by `onError` (markdownlint only accepts body line numbers), so metadata findings report at line 1.

### `material-mermaid-syntax` (2 cases)
- Bracket/brace balance was checked **per line**, so a multi-line `classDiagram`/`stateDiagram` body (`class Animal {` … `}`) produced false "unmatched braces" errors. Balance is now a whole-block check.
- `A --> B` edges now count as node definitions, so a directionless flowchart reports only the missing-direction error, not a bogus missing-nodes one.

### `material-footnotes-syntax` (3 cases)
A definition line's own `[^id]` label was counted as a reference to itself. That masked "definition never referenced" reports and inflated "reference has no definition" errors. The scanner now skips the leading label on definition lines and registers colon-less (malformed) definitions.

## Test changes
- All 8 previously-hidden failures now pass.
- Corrected one **stale** expectation: the `material-meta-tags` "Long description" case used a 144-char description (under the 160 threshold) — it only ever "passed" via the missing-front-matter false positive. Bumped it past 160.
- Added regression cases: a multi-line-brace mermaid state diagram, an orphan-among-valid footnote definition, and a list-style-tags front matter page.

## Verification
`npm test` → exit 0, `npm run lint` → exit 0. Suite totals: icons 8/8, meta-tags 11/11, mermaid 15/15, footnotes 14/14, fixtures 14/14, data-style 32/32.

## Note
Per the current release state, the CHANGELOG's `1.5.4` section is marked **Unreleased** (these fixes land there since 1.5.4 hasn't been published yet).